### PR TITLE
docs(TALK-57): add README, CHANGELOG, update package.json for npm publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.2] - 2026-03-13
+
+### Added
+- MissionObserver: background cron loop replaces heartbeat-driven polling
+- Mission event handling via WebSocket (call_completed, call_failed, insights_ready, sms_delivered)
+- SMS thread context injected into mission sessions
+- Tool-level guardrails for mission lifecycle (state machine enforcement)
+- Mission SKILL.md rewritten for webhook-driven architecture
+
+### Changed
+- Mission lifecycle is now fully event-driven (WebSocket push, observer as safety net)
+- Loosened MissionObserver `collectActions` for edge cases
+
+## [0.1.1] - 2026-03-11
+
+### Added
+- `openclaw clawtalk doctor` and `openclaw clawtalk config` CLI commands
+- `openclaw clawtalk logs` for tailing WebSocket log
+
+### Fixed
+- Biome lint and formatting cleanup
+- CI: use `npm install` for cross-version compatibility
+- Replace `stty` with `tty.ReadStream` for portability
+
+### Removed
+- Install script (replaced by `openclaw plugins install`)
+
+## [0.1.0] - 2026-03-09
+
+Initial release.
+
+### Added
+- **Phase 1:** Plugin scaffold (openclaw.plugin.json, TypeScript, Biome, Vitest)
+- **Phase 2:** ClawTalkClient SDK with Stripe-style namespaced API (calls, sms, missions, assistants, numbers, insights, approvals, doctor, user)
+- **Phase 3:** Event handlers (CallHandler, DeepToolHandler, SmsHandler, WalkieHandler, ApprovalManager)
+- **Phase 4:** 20 agent tools (7 communication, 11 mission, 2 standalone)
+- **Phase 5:** MissionService with full lifecycle management, MissionEventHandler for real-time events
+- **Phase 6:** Plugin entry point with CoreBridge (in-process agent execution), WebSocketService with persistent connection, health endpoint
+- **Phase 7A:** GitHub Actions CI workflow, VoiceService, DoctorService
+- PIN authentication for inbound calls
+- Whitelist support for calls and SMS
+- External caller tool blocking (whitelisted callbacks cannot invoke agent tools)
+- WebSocket log file with API key redaction and rotation
+- TypeBox schemas for all tool parameters
+- 110+ tests across SDK, services, and tools

--- a/README.md
+++ b/README.md
@@ -1,0 +1,207 @@
+# ClawTalk
+
+OpenClaw plugin for [ClawTalk](https://clawdtalk.com) — voice calls, SMS, AI missions, and push-notification approvals.
+
+Your AI agent gets a phone number. It can make and receive calls, send and receive texts, run multi-step outreach campaigns (missions), and request approval for sensitive actions via push notification.
+
+**Powered by [Telnyx](https://telnyx.com).**
+
+## Install
+
+```bash
+openclaw plugins install clawtalk
+```
+
+## Prerequisites
+
+- [OpenClaw](https://openclaw.ai) installed and running
+- A [ClawTalk](https://clawdtalk.com) account with an API key
+
+## Configuration
+
+Add to your OpenClaw gateway config:
+
+```yaml
+plugins:
+  clawtalk:
+    apiKey: "your-clawtalk-api-key"
+    ownerName: "Your Name"        # Used in voice greetings
+    agentName: "Your Agent"       # Agent identity on calls
+```
+
+### All Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `apiKey` | — | **Required.** ClawTalk API key |
+| `server` | `https://clawdtalk.com` | ClawTalk server URL |
+| `ownerName` | `"there"` | Your name (used in greetings) |
+| `agentName` | `"ClawTalk"` | Agent name for voice context |
+| `greeting` | `"Hey {ownerName}, what's up?"` | Custom inbound call greeting |
+| `agentId` | `"main"` | OpenClaw agent ID |
+| `autoConnect` | `true` | Connect WebSocket on startup |
+| `voiceContext` | Built-in | Override the voice system prompt |
+| `missions.enabled` | `true` | Enable mission tools |
+| `missions.defaultVoice` | — | Default TTS voice for mission assistants |
+| `missions.defaultModel` | — | Default LLM for mission assistants |
+| `missions.observer.enabled` | `true` | Background mission lifecycle checks |
+| `missions.observer.intervalMs` | `300000` | Observer check interval (5 min) |
+| `missions.observer.staleThresholdMs` | `7200000` | Stale mission threshold (2 hours) |
+
+## What It Does
+
+### Voice Calls
+
+- **Inbound:** Your agent answers calls on its dedicated number. Callers authenticate via PIN, then talk directly to the AI assistant with full tool access.
+- **Outbound:** Schedule calls to external numbers. The AI assistant handles the conversation with custom instructions and greeting.
+- **Deep tool routing:** During calls, the Telnyx Voice AI can invoke your OpenClaw agent's tools (search the web, check Slack, read memory) and speak the results back to the caller.
+- **Push-to-talk:** Walkie-talkie style messages from the ClawTalk mobile app, processed by the agent and replied to via voice.
+
+### SMS
+
+- **Send and receive:** Full SMS/MMS support. Inbound messages create persistent per-number conversation sessions.
+- **Mission SMS:** Schedule texts as part of multi-step campaigns. Replies from targets are routed into the correct mission context with thread history.
+
+### Missions
+
+Missions are multi-step outreach campaigns. The agent creates a plan, sets up a voice assistant, schedules calls and texts, and processes results in real-time via WebSocket events.
+
+- **Dedicated session per mission** — no context bleed between concurrent missions
+- **Real-time event handling** — call transcripts, SMS replies, delivery confirmations, and AI insights arrive via WebSocket
+- **Step lifecycle enforcement** — state machine prevents invalid transitions (no going backwards from completed/failed)
+- **Background observer** — detects stale missions, unresolved call outcomes, and completed-but-unclosed missions
+
+### Approvals
+
+Request user approval for sensitive actions via push notification to the ClawTalk mobile app. Supports biometric confirmation (Face ID / fingerprint) for high-security actions.
+
+### Health & Diagnostics
+
+- Built-in doctor checks (WebSocket, CoreBridge roundtrip, server health)
+- WebSocket log file with automatic rotation and API key redaction
+- CLI: `openclaw clawtalk logs` to tail the WebSocket log
+
+## Tools
+
+The plugin registers 20 agent tools:
+
+### Communication
+
+| Tool | Description |
+|------|-------------|
+| `clawtalk_call` | Initiate an outbound phone call |
+| `clawtalk_call_status` | Check call status or hang up |
+| `clawtalk_sms` | Send SMS or MMS |
+| `clawtalk_sms_list` | List recent messages (filter by contact/direction) |
+| `clawtalk_sms_conversations` | List SMS conversations |
+| `clawtalk_approve` | Request push-notification approval |
+| `clawtalk_status` | Check connection, version, WebSocket health |
+
+### Missions
+
+| Tool | Description |
+|------|-------------|
+| `clawtalk_mission_init` | Create a mission with plan steps |
+| `clawtalk_mission_setup_agent` | Create voice assistant and link to mission |
+| `clawtalk_mission_schedule` | Schedule a call or SMS event |
+| `clawtalk_mission_event_status` | Check scheduled event status |
+| `clawtalk_mission_update_step` | Update plan step (state machine enforced) |
+| `clawtalk_mission_log_event` | Log an event to the mission run |
+| `clawtalk_mission_memory` | Save/load/append mission memory |
+| `clawtalk_mission_complete` | Complete mission (all steps must be terminal) |
+| `clawtalk_mission_list` | List missions (local state or server API) |
+| `clawtalk_mission_get_plan` | Get plan steps from server |
+| `clawtalk_mission_cancel_event` | Cancel a scheduled event |
+
+### Standalone
+
+| Tool | Description |
+|------|-------------|
+| `clawtalk_assistants` | List, create, get, or update voice assistants |
+| `clawtalk_insights` | Get AI-generated conversation insights |
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────┐
+│                  OpenClaw Gateway                │
+│                                                  │
+│  ┌──────────────────────────────────────────┐   │
+│  │            ClawTalk Plugin                │   │
+│  │                                           │   │
+│  │  ┌─────────────┐   ┌──────────────────┐  │   │
+│  │  │ ClawTalkSDK │   │  WebSocketService │──┼───┼──→ ClawTalk Server
+│  │  │ (REST API)  │   │  (persistent WS)  │  │   │
+│  │  └─────────────┘   └────────┬─────────┘  │   │
+│  │                              │            │   │
+│  │  ┌──────────┐  ┌────────────┤            │   │
+│  │  │CoreBridge│  │ Event Handlers:          │   │
+│  │  │(in-proc  │←─┤ • CallHandler            │   │
+│  │  │ agent)   │  │ • DeepToolHandler        │   │
+│  │  └──────────┘  │ • SmsHandler             │   │
+│  │       ↑        │ • WalkieHandler          │   │
+│  │       │        │ • MissionEventHandler    │   │
+│  │  23 Agent      │ • ApprovalManager        │   │
+│  │   Tools        └──────────────────────────┘  │
+│  └──────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────┘
+```
+
+**CoreBridge** runs agent turns in-process via OpenClaw's extension API. No HTTP round-trips to the gateway. Each channel (voice, SMS, walkie, mission) gets its own persistent session.
+
+**WebSocketService** maintains a persistent connection to the ClawTalk server with authentication, ping/pong keepalive, exponential backoff reconnect, and typed event dispatch.
+
+**MissionObserver** runs on a background interval (default 5 min), independent of chat turns. Detects stuck missions and nudges the appropriate mission session.
+
+## Security
+
+- **PIN authentication** on inbound calls (configurable per user)
+- **Whitelist** for calls and SMS (silently drops non-whitelisted contacts)
+- **Lakera Guard** screens all external SMS and voice tool requests for prompt injection
+- **STIR/SHAKEN** verification with paranoid mode (reject unverified callers)
+- **External caller tool blocking** — whitelisted callbacks can converse but cannot invoke agent tools
+- **Push-notification approvals** with optional biometric confirmation
+- **IO screening** fails closed (service unavailable = request blocked)
+
+## Development
+
+```bash
+git clone https://github.com/team-telnyx/clawtalk-plugin
+cd clawtalk-plugin
+npm install
+npm run typecheck    # TypeScript check
+npm run lint         # Biome linter
+npm run test         # Vitest test suite
+npm run build        # SWC compiler → build/
+```
+
+### Project Structure
+
+```
+src/
+├── index.ts                    # Plugin entry point
+├── config.ts                   # Config interface + defaults
+├── cli.ts                      # CLI commands (openclaw clawtalk logs)
+├── tools/                      # 23 agent tools
+├── services/
+│   ├── CoreBridge.ts           # In-process agent execution
+│   ├── WebSocketService.ts     # Persistent WS connection
+│   ├── CallHandler.ts          # Call lifecycle (context, greeting, outcome)
+│   ├── DeepToolHandler.ts      # Voice → agent tool routing
+│   ├── SmsHandler.ts           # Inbound SMS → agent → reply
+│   ├── WalkieHandler.ts        # Push-to-talk
+│   ├── MissionEventHandler.ts  # Real-time mission events
+│   ├── MissionObserver.ts      # Background lifecycle checks
+│   ├── MissionService.ts       # Mission state + API orchestration
+│   ├── ApprovalManager.ts      # Push notification approvals
+│   ├── VoiceService.ts         # Voice context + TTS cleanup
+│   └── DoctorService.ts        # Health checks
+├── lib/clawtalk-sdk/           # Typed REST client (Stripe-style namespaces)
+├── routes/                     # HTTP endpoints (/clawtalk/health)
+├── types/                      # TypeScript type definitions
+└── utils/                      # Errors, formatting, WS logger
+```
+
+## License
+
+MIT

--- a/package.json
+++ b/package.json
@@ -37,10 +37,30 @@
   "files": [
     "build",
     "openclaw.plugin.json",
-    "skills"
+    "skills",
+    "README.md"
   ],
   "openclaw": {
     "extensions": ["./build/index.js"]
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/team-telnyx/clawtalk-plugin"
+  },
+  "homepage": "https://clawdtalk.com",
+  "bugs": {
+    "url": "https://github.com/team-telnyx/clawtalk-plugin/issues"
+  },
+  "author": "ClawdTalk <support@clawdtalk.com>",
+  "keywords": [
+    "openclaw",
+    "openclaw-plugin",
+    "voice",
+    "calls",
+    "sms",
+    "ai-assistant",
+    "telnyx",
+    "clawtalk"
+  ],
   "license": "MIT"
 }


### PR DESCRIPTION
## README, CHANGELOG & npm metadata for community publish

**TALK-57** (Phase 8A: Community Plugin)

- **README.md** — install, config, 20-tool reference table, architecture diagram, security overview
- **CHANGELOG.md** — v0.1.0 → v0.1.2 history
- **package.json** — added repository, homepage, bugs, author, keywords; README in files array

Package is live on npm: `npm install clawtalk`