### PR TITLE
chore: supporting install on older versions of clawdbot

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
       "./build/index.js"
     ]
   },
-  "clawbot": {
+  "clawdbot": {
     "extensions": [
       "./build/index.js"
     ]


### PR DESCRIPTION
This update resolves the following issue:

<img width="1703" height="383" alt="image" src="https://github.com/user-attachments/assets/3da9caa6-8061-4066-a072-0f6ecdab950d" />

**Explanation**:  Older versions of OpenClaw (named clawdbot) throw an error when running the install script, because the `package.json` of the plugin only references openclaw. 

**Fix**: Both openclaw and clawdbot paths are supported in the `package.json` now.