### PR TITLE
fix(TALK-66): don't send default agent name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawtalk",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Voice calls, SMS, missions, and approvals via ClawTalk — OpenClaw plugin",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/src/lib/clawtalk-sdk/endpoints.ts
+++ b/src/lib/clawtalk-sdk/endpoints.ts
@@ -37,6 +37,7 @@ export interface Endpoint {
 export const ENDPOINTS = {
   // ── User (/v1 + user.js) ────────────────────────────────
   getMe: { method: 'GET', path: '/v1/me', sdkMethod: 'getMe', write: false },
+  updateMe: { method: 'PATCH', path: '/v1/me', sdkMethod: 'updateMe', write: true },
 
   // ── Calls (/v1/calls + calls.js) ────────────────────────
   initiateCall: { method: 'POST', path: '/v1/calls', sdkMethod: 'initiateCall', write: true },

--- a/src/lib/clawtalk-sdk/namespaces/user.ts
+++ b/src/lib/clawtalk-sdk/namespaces/user.ts
@@ -8,4 +8,8 @@ export class UserNamespace {
   async me(): Promise<UserMeResponse> {
     return this.request<UserMeResponse>('GET', ENDPOINTS.getMe.path);
   }
+
+  async updateMe(fields: Record<string, unknown>): Promise<UserMeResponse> {
+    return this.request<UserMeResponse>('PATCH', ENDPOINTS.updateMe.path, { body: fields });
+  }
 }

--- a/src/lib/clawtalk-sdk/types.ts
+++ b/src/lib/clawtalk-sdk/types.ts
@@ -35,7 +35,12 @@ export interface UserMeResponse {
   readonly effective_days_remaining: number | null;
   readonly subscription_status: string;
   readonly paranoid_mode: boolean;
-  readonly voice_preference: string | null;
+  readonly agent_name?: string | null;
+  readonly display_name?: string | null;
+  readonly bot_role?: string | null;
+  readonly custom_instructions?: string | null;
+  readonly greeting?: string | null;
+  readonly voice_preference?: string | null;
   readonly system_number: string | null;
   readonly dedicated_number: string | null;
   readonly totp_enabled: boolean;

--- a/src/services/WebSocketService.ts
+++ b/src/services/WebSocketService.ts
@@ -265,7 +265,7 @@ export class WebSocketService extends TypedEmitter<WebSocketEvents> {
       api_key: this.config.apiKey,
       client_version: this.clientVersion,
       owner_name: this.config.ownerName !== 'there' ? this.config.ownerName : undefined,
-      agent_name: this.config.agentName,
+      agent_name: this.config.agentName !== 'ClawTalk' ? this.config.agentName : undefined,
     };
 
     this.ws.send(JSON.stringify(authMsg));

--- a/src/tools/BotConfigTool.ts
+++ b/src/tools/BotConfigTool.ts
@@ -1,0 +1,92 @@
+import { Type } from '@sinclair/typebox';
+import type { ClawTalkClient } from '../lib/clawtalk-sdk/index.js';
+import type { Logger } from '../types/plugin.js';
+import { ToolError } from '../utils/errors.js';
+
+export const BotConfigToolSchema = Type.Object({
+  action: Type.Union([Type.Literal('get'), Type.Literal('update')]),
+  agent_name: Type.Optional(Type.String({ description: 'Bot name (e.g. Daisy)' })),
+  bot_role: Type.Optional(
+    Type.String({ description: 'Bot role (e.g. live phone voice for Smokies Motels)' }),
+  ),
+  custom_instructions: Type.Optional(
+    Type.String({ description: 'Custom behaviour instructions, business rules, pricing, etc.' }),
+  ),
+  greeting: Type.Optional(Type.String({ description: 'Greeting spoken when a call connects' })),
+  voice_preference: Type.Optional(Type.String({ description: 'Voice ID (e.g. Rime.ArcanaV3.astra)' })),
+});
+
+function formatResult(payload: unknown) {
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify(payload, null, 2) }],
+    details: payload,
+  };
+}
+
+export class BotConfigTool {
+  private readonly client: ClawTalkClient;
+  private readonly logger: Logger;
+
+  readonly name = 'clawtalk_bot_config';
+  readonly label = 'ClawTalk Bot Config';
+  readonly description =
+    'Read or update the bot configuration (name, role, custom instructions, greeting, voice). Use action "get" to read current config, "update" to change fields.';
+  readonly parameters = BotConfigToolSchema;
+
+  constructor(params: { client: ClawTalkClient; logger: Logger }) {
+    this.client = params.client;
+    this.logger = params.logger;
+  }
+
+  async execute(_toolCallId: string, raw: Record<string, unknown>) {
+    const action = raw.action as string;
+
+    if (action === 'get') {
+      this.logger.info('Getting bot config');
+      try {
+        const me = await this.client.user.me();
+        const config = {
+          agent_name: me.agent_name ?? null,
+          display_name: me.display_name ?? null,
+          bot_role: me.bot_role ?? 'personal AI assistant',
+          custom_instructions: me.custom_instructions ?? null,
+          greeting: me.greeting ?? null,
+          voice_preference: me.voice_preference ?? null,
+        };
+        return formatResult(config);
+      } catch (err) {
+        throw ToolError.fromError('clawtalk_bot_config', err);
+      }
+    }
+
+    if (action === 'update') {
+      this.logger.info('Updating bot config');
+      const fields: Record<string, unknown> = {};
+      for (const key of ['agent_name', 'bot_role', 'custom_instructions', 'greeting', 'voice_preference']) {
+        if (raw[key] !== undefined) fields[key] = raw[key];
+      }
+      if (Object.keys(fields).length === 0) {
+        throw new ToolError('clawtalk_bot_config', 'No fields provided for update');
+      }
+      try {
+        await this.client.user.updateMe(fields);
+        // Read back to confirm
+        const me = await this.client.user.me();
+        const config = {
+          agent_name: me.agent_name ?? null,
+          display_name: me.display_name ?? null,
+          bot_role: me.bot_role ?? 'personal AI assistant',
+          custom_instructions: me.custom_instructions ?? null,
+          greeting: me.greeting ?? null,
+          voice_preference: me.voice_preference ?? null,
+          message: 'Bot config updated. Changes take effect on the next call.',
+        };
+        return formatResult(config);
+      } catch (err) {
+        throw ToolError.fromError('clawtalk_bot_config', err);
+      }
+    }
+
+    throw new ToolError('clawtalk_bot_config', `Unknown action: ${action}`);
+  }
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -13,6 +13,7 @@ import type { WebSocketService } from '../services/WebSocketService.js';
 import type { Logger } from '../types/plugin.js';
 import { ApproveTool } from './ApproveTool.js';
 import { AssistantsTool } from './AssistantsTool.js';
+import { BotConfigTool } from './BotConfigTool.js';
 import { CallStatusTool, CallTool } from './CallTool.js';
 import { InsightsTool } from './InsightsTool.js';
 import {
@@ -73,6 +74,7 @@ export function createTools(services: ToolServices): ClawTalkTool[] {
     new SmsConversationsTool({ client, logger }),
     new ApproveTool({ approvalManager, logger }),
     new StatusTool({ config, client, ws, logger }),
+    new BotConfigTool({ client, logger }),
 
     // Phase 5: Mission lifecycle
     new MissionInitTool(missionDeps),


### PR DESCRIPTION
- The agent name in the portal was being set to the default "ClawTalk" every time the agent connected. 
- This is now fixed. The agent name is only sent on connect if not set to the default.