### PR TITLE
fix: only send agent name if not default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawtalk",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Voice calls, SMS, missions, and approvals via ClawTalk — OpenClaw plugin",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/src/services/WebSocketService.ts
+++ b/src/services/WebSocketService.ts
@@ -265,7 +265,7 @@ export class WebSocketService extends TypedEmitter<WebSocketEvents> {
       api_key: this.config.apiKey,
       client_version: this.clientVersion,
       owner_name: this.config.ownerName !== 'there' ? this.config.ownerName : undefined,
-      agent_name: this.config.agentName,
+      agent_name: this.config.agentName !== 'ClawTalk' ? this.config.agentName : undefined,
     };
 
     this.ws.send(JSON.stringify(authMsg));


### PR DESCRIPTION
This fixes a bug where your agent name in the portal would be set to ClawTalk every time the websocket connected.