### PR TITLE
feat(TALK-16): adding bot configuration tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2026-03-25
+
+### Added
+- **BotConfigTool** (`clawtalk_bot_config`): New tool for managing bot settings
+  - `get` action: Read current bot config (name, role, greeting, voice, language, instructions)
+  - `update` action: Update any combination of bot settings
+  - `list_voices` action: Browse 2,200+ TTS voices with filters (provider, language, gender, accent, search)
+  - Voice cache with 5 minute TTL per provider
+  - Results capped at 20 with total count to prevent context bloat
+- **VoicesNamespace** in ClawTalk SDK: `client.voices.list(provider?)` method
+- 22 new tests for BotConfigTool
+
+### Changed
+- **Mission assistant voice inheritance**: `clawtalk_mission_setup_agent` no longer defaults to `Rime.ArcanaV3.astra`
+  - If `voice` param omitted, server now uses user's `voice_preference` (with fallback to system default)
+  - Explicit `voice` param still works for override
+- Updated MissionTool schema description to reflect voice inheritance behavior
+
 ## [0.1.4] - 2026-03-16
 
 ### Removed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawtalk",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "Voice calls, SMS, missions, and approvals via ClawTalk — OpenClaw plugin",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/src/lib/clawtalk-sdk/client.ts
+++ b/src/lib/clawtalk-sdk/client.ts
@@ -20,6 +20,7 @@ import { MissionsNamespace } from './namespaces/missions.js';
 import { NumbersNamespace } from './namespaces/numbers.js';
 import { SmsNamespace } from './namespaces/sms.js';
 import { UserNamespace } from './namespaces/user.js';
+import { VoicesNamespace } from './namespaces/voices.js';
 
 export interface ClawTalkClientConfig {
   readonly apiKey: string;
@@ -42,6 +43,7 @@ export class ClawTalkClient {
   readonly numbers: NumbersNamespace;
   readonly insights: InsightsNamespace;
   readonly doctor: DoctorNamespace;
+  readonly voices: VoicesNamespace;
 
   private readonly baseUrl: string;
   private readonly headers: Record<string, string>;
@@ -69,6 +71,7 @@ export class ClawTalkClient {
     this.numbers = new NumbersNamespace(request);
     this.insights = new InsightsNamespace(request);
     this.doctor = new DoctorNamespace(request);
+    this.voices = new VoicesNamespace(request);
   }
 
   private async request<T>(method: string, endpoint: string, body?: unknown): Promise<T> {

--- a/src/lib/clawtalk-sdk/endpoints.ts
+++ b/src/lib/clawtalk-sdk/endpoints.ts
@@ -37,6 +37,10 @@ export interface Endpoint {
 export const ENDPOINTS = {
   // ── User (/v1 + user.js) ────────────────────────────────
   getMe: { method: 'GET', path: '/v1/me', sdkMethod: 'getMe', write: false },
+  updateMe: { method: 'PATCH', path: '/v1/me', sdkMethod: 'updateMe', write: true },
+
+  // ── Voices (/v1 + user.js) ───────────────────────────────
+  listVoices: { method: 'GET', path: '/v1/voices', sdkMethod: 'listVoices', write: false },
 
   // ── Calls (/v1/calls + calls.js) ────────────────────────
   initiateCall: { method: 'POST', path: '/v1/calls', sdkMethod: 'initiateCall', write: true },

--- a/src/lib/clawtalk-sdk/index.ts
+++ b/src/lib/clawtalk-sdk/index.ts
@@ -66,4 +66,6 @@ export type {
   SmsResponse,
   UpdateStepParams,
   UserMeResponse,
+  Voice,
+  VoicesResponse,
 } from './types.js';

--- a/src/lib/clawtalk-sdk/namespaces/user.ts
+++ b/src/lib/clawtalk-sdk/namespaces/user.ts
@@ -8,4 +8,8 @@ export class UserNamespace {
   async me(): Promise<UserMeResponse> {
     return this.request<UserMeResponse>('GET', ENDPOINTS.getMe.path);
   }
+
+  async updateMe(fields: Record<string, unknown>): Promise<void> {
+    await this.request('PATCH', ENDPOINTS.updateMe.path, fields);
+  }
 }

--- a/src/lib/clawtalk-sdk/namespaces/voices.ts
+++ b/src/lib/clawtalk-sdk/namespaces/voices.ts
@@ -1,0 +1,12 @@
+import { ENDPOINTS } from '../endpoints.js';
+import type { VoicesResponse } from '../types.js';
+import type { RequestFn } from './calls.js';
+
+export class VoicesNamespace {
+  constructor(private readonly request: RequestFn) {}
+
+  async list(provider?: string): Promise<VoicesResponse> {
+    const query = provider ? `?provider=${encodeURIComponent(provider)}` : '';
+    return this.request<VoicesResponse>('GET', `${ENDPOINTS.listVoices.path}${query}`);
+  }
+}

--- a/src/lib/clawtalk-sdk/types.ts
+++ b/src/lib/clawtalk-sdk/types.ts
@@ -36,6 +36,11 @@ export interface UserMeResponse {
   readonly subscription_status: string;
   readonly paranoid_mode: boolean;
   readonly voice_preference: string | null;
+  readonly agent_name: string | null;
+  readonly display_name: string | null;
+  readonly bot_role: string | null;
+  readonly custom_instructions: string | null;
+  readonly greeting: string | null;
   readonly system_number: string | null;
   readonly dedicated_number: string | null;
   readonly totp_enabled: boolean;
@@ -60,6 +65,27 @@ export interface UserMeResponse {
     readonly call_seconds: number;
     readonly mission_events: number;
   };
+}
+
+// ── Voices ────────────────────────────────────────────────────
+
+export interface Voice {
+  readonly id: string;
+  readonly name: string;
+  readonly provider: string;
+  readonly model: string | null;
+  readonly language: string;
+  readonly gender: string | null;
+  readonly label: string | null;
+  readonly accent: string | null;
+  readonly age: string | null;
+}
+
+export interface VoicesResponse {
+  readonly default_voice: string;
+  readonly voices: Voice[];
+  readonly providers: string[];
+  readonly total: number;
 }
 
 // ── Calls ─────────────────────────────────────────────────────

--- a/src/services/MissionService.ts
+++ b/src/services/MissionService.ts
@@ -221,7 +221,7 @@ export class MissionService {
       name: params.name,
       instructions: params.instructions,
       greeting: params.greeting ?? '',
-      voice: params.voice ?? 'Rime.ArcanaV3.astra',
+      voice: params.voice,
       model: params.model ?? 'openai/gpt-4o',
       tools: params.tools as Array<{ type: string; [key: string]: unknown }>,
       enabled_features: params.features ?? ['telephony', 'messaging'],

--- a/src/tools/BotConfigTool.ts
+++ b/src/tools/BotConfigTool.ts
@@ -1,0 +1,224 @@
+/**
+ * BotConfigTool — clawtalk_bot_config: Read, update bot configuration, or browse voices.
+ */
+
+import { Type } from '@sinclair/typebox';
+import type { ClawTalkClient } from '../lib/clawtalk-sdk/index.js';
+import type { Voice } from '../lib/clawtalk-sdk/types.js';
+import type { Logger } from '../types/plugin.js';
+import { ToolError } from '../utils/errors.js';
+
+// ── Schema ──────────────────────────────────────────────────
+
+export const BotConfigToolSchema = Type.Object({
+  action: Type.Union([Type.Literal('get'), Type.Literal('update'), Type.Literal('list_voices')]),
+  agent_name: Type.Optional(Type.String({ description: 'Bot name (e.g. Daisy)' })),
+  bot_role: Type.Optional(Type.String({ description: 'Bot role (e.g. live phone voice for Smokies Motels)' })),
+  custom_instructions: Type.Optional(
+    Type.String({ description: 'Custom behaviour instructions, business rules, pricing, etc.' }),
+  ),
+  greeting: Type.Optional(Type.String({ description: 'Greeting spoken when a call connects' })),
+  voice_preference: Type.Optional(Type.String({ description: 'Voice ID (e.g. Rime.ArcanaV3.astra)' })),
+  // list_voices filters
+  provider: Type.Optional(
+    Type.String({
+      description:
+        'Voice provider. Required for list_voices (default: "rime"). Options: rime, minimax, telnyx, inworld, resemble, aws, azure',
+    }),
+  ),
+  language: Type.Optional(Type.String({ description: 'Filter by language code (e.g. "en", "es", "fr-FR")' })),
+  gender: Type.Optional(Type.String({ description: 'Filter by gender ("Male" or "Female")' })),
+  accent: Type.Optional(Type.String({ description: 'Filter by accent (e.g. "British", "Southern American")' })),
+  search: Type.Optional(Type.String({ description: 'Search voice name or label' })),
+});
+
+// ── Voice Cache ─────────────────────────────────────────────
+
+interface CacheEntry {
+  voices: Voice[];
+  providers: string[];
+  defaultVoice: string;
+  fetchedAt: number;
+}
+
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const voiceCache = new Map<string, CacheEntry>();
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function formatResult(payload: unknown) {
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify(payload, null, 2) }],
+    details: payload,
+  };
+}
+
+function truncate(str: string | null, max: number): string | null {
+  if (!str) return null;
+  return str.length > max ? `${str.slice(0, max - 1)}_` : str;
+}
+
+// ── Tool ─────────────────────────────────────────────────────
+
+export class BotConfigTool {
+  readonly name = 'clawtalk_bot_config';
+  readonly label = 'ClawTalk Bot Config';
+  readonly description =
+    'Read or update the bot configuration (name, role, custom instructions, greeting, voice). Use action "get" to read current config, "update" to change fields, "list_voices" to browse available voices by provider.';
+  readonly parameters = BotConfigToolSchema;
+
+  private readonly client: ClawTalkClient;
+  private readonly logger: Logger;
+
+  constructor(params: { client: ClawTalkClient; logger: Logger }) {
+    this.client = params.client;
+    this.logger = params.logger;
+  }
+
+  async execute(_toolCallId: string, raw: Record<string, unknown>) {
+    const { action } = raw as { action: string };
+
+    if (action === 'get') {
+      return this.handleGet();
+    }
+
+    if (action === 'update') {
+      return this.handleUpdate(raw);
+    }
+
+    if (action === 'list_voices') {
+      return this.handleListVoices(raw);
+    }
+
+    throw new ToolError('clawtalk_bot_config', `Unknown action: ${action}`);
+  }
+
+  private async handleGet() {
+    this.logger.info('Getting bot config');
+    try {
+      const me = await this.client.user.me();
+      const config = {
+        agent_name: me.agent_name ?? null,
+        display_name: me.display_name ?? null,
+        bot_role: me.bot_role ?? 'personal AI assistant',
+        custom_instructions: me.custom_instructions ?? null,
+        greeting: me.greeting ?? null,
+        voice_preference: me.voice_preference ?? null,
+      };
+      return formatResult(config);
+    } catch (err) {
+      throw ToolError.fromError('clawtalk_bot_config', err);
+    }
+  }
+
+  private async handleUpdate(raw: Record<string, unknown>) {
+    this.logger.info('Updating bot config');
+    const fields: Record<string, unknown> = {};
+    for (const key of ['agent_name', 'bot_role', 'custom_instructions', 'greeting', 'voice_preference']) {
+      if (raw[key] !== undefined) fields[key] = raw[key];
+    }
+    if (Object.keys(fields).length === 0) {
+      throw new ToolError('clawtalk_bot_config', 'No fields provided for update');
+    }
+    try {
+      await this.client.user.updateMe(fields);
+      const me = await this.client.user.me();
+      const config = {
+        agent_name: me.agent_name ?? null,
+        display_name: me.display_name ?? null,
+        bot_role: me.bot_role ?? 'personal AI assistant',
+        custom_instructions: me.custom_instructions ?? null,
+        greeting: me.greeting ?? null,
+        voice_preference: me.voice_preference ?? null,
+        message: 'Bot config updated. Changes take effect on the next call.',
+      };
+      return formatResult(config);
+    } catch (err) {
+      throw ToolError.fromError('clawtalk_bot_config', err);
+    }
+  }
+
+  private async handleListVoices(raw: Record<string, unknown>) {
+    const provider = (raw.provider as string) || 'rime';
+    const language = raw.language as string | undefined;
+    const gender = raw.gender as string | undefined;
+    const accent = raw.accent as string | undefined;
+    const search = raw.search as string | undefined;
+
+    this.logger.info(`Listing voices for provider: ${provider}`);
+
+    try {
+      // Check cache
+      const cached = voiceCache.get(provider);
+      let voices: Voice[];
+      let defaultVoice: string;
+      let allProviders: string[];
+
+      if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+        voices = cached.voices;
+        defaultVoice = cached.defaultVoice;
+        allProviders = cached.providers;
+      } else {
+        const result = await this.client.voices.list(provider);
+        voices = result.voices;
+        defaultVoice = result.default_voice;
+        allProviders = result.providers;
+        voiceCache.set(provider, {
+          voices,
+          providers: allProviders,
+          defaultVoice,
+          fetchedAt: Date.now(),
+        });
+      }
+
+      // Apply client-side filters
+      let filtered = voices;
+
+      if (language) {
+        const lang = language.toLowerCase();
+        filtered = filtered.filter((v) => v.language.toLowerCase().startsWith(lang));
+      }
+
+      if (gender) {
+        const g = gender.toLowerCase();
+        filtered = filtered.filter((v) => v.gender?.toLowerCase() === g);
+      }
+
+      if (accent) {
+        const a = accent.toLowerCase();
+        filtered = filtered.filter((v) => v.accent?.toLowerCase().includes(a));
+      }
+
+      if (search) {
+        const s = search.toLowerCase();
+        filtered = filtered.filter(
+          (v) =>
+            v.name.toLowerCase().includes(s) ||
+            v.id.toLowerCase().includes(s) ||
+            (v.label?.toLowerCase().includes(s) ?? false),
+        );
+      }
+
+      const totalMatching = filtered.length;
+      const capped = filtered.slice(0, 20);
+
+      return formatResult({
+        default_voice: defaultVoice,
+        provider,
+        providers: allProviders,
+        total_matching: totalMatching,
+        showing: capped.length,
+        voices: capped.map((v) => ({
+          id: v.id,
+          name: v.name,
+          provider: v.provider,
+          language: v.language,
+          gender: v.gender,
+          label: truncate(v.label, 80),
+        })),
+      });
+    } catch (err) {
+      throw ToolError.fromError('clawtalk_bot_config', err);
+    }
+  }
+}

--- a/src/tools/MissionTool.ts
+++ b/src/tools/MissionTool.ts
@@ -58,7 +58,7 @@ export const MissionSetupAgentSchema = Type.Object({
   name: Type.String({ description: 'Assistant name' }),
   instructions: Type.String({ description: 'Voice agent instructions' }),
   greeting: Type.Optional(Type.String({ description: 'Greeting spoken when call connects. Default: empty' })),
-  voice: Type.Optional(Type.String({ description: 'Voice model. Default: Rime.ArcanaV3.astra' })),
+  voice: Type.Optional(Type.String({ description: 'Voice model. Default: inherits user voice preference' })),
   model: Type.Optional(Type.String({ description: 'LLM model. Default: openai/gpt-4o' })),
 });
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -13,6 +13,7 @@ import type { WebSocketService } from '../services/WebSocketService.js';
 import type { Logger } from '../types/plugin.js';
 import { ApproveTool } from './ApproveTool.js';
 import { AssistantsTool } from './AssistantsTool.js';
+import { BotConfigTool } from './BotConfigTool.js';
 import { CallStatusTool, CallTool } from './CallTool.js';
 import { InsightsTool } from './InsightsTool.js';
 import {
@@ -66,6 +67,7 @@ export function createTools(services: ToolServices): ClawTalkTool[] {
 
   return [
     // Phase 4
+    new BotConfigTool({ client, logger }),
     new CallTool({ client, logger }),
     new CallStatusTool({ client, logger }),
     new SmsTool({ client, logger }),

--- a/test/tools/BotConfigTool.test.ts
+++ b/test/tools/BotConfigTool.test.ts
@@ -1,0 +1,405 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BotConfigTool } from '../../src/tools/BotConfigTool.js';
+import type { ClawTalkClient } from '../../src/lib/clawtalk-sdk/index.js';
+import type { Logger } from '../../src/types/plugin.js';
+
+// ── Mocks ───────────────────────────────────────────────────
+
+function createMockLogger(): Logger {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+}
+
+const mockUserData = {
+  user_id: 'user_123',
+  agent_name: 'PAL-01',
+  display_name: 'Ciaran',
+  bot_role: 'Personal assistant',
+  custom_instructions: 'Be helpful.',
+  greeting: 'Hey, what do you need?',
+  voice_preference: 'Minimax.speech-2.8-turbo.English_Aussie_Bloke',
+};
+
+const mockVoices = [
+  {
+    id: 'Rime.ArcanaV3.astra',
+    name: 'Astra',
+    provider: 'rime',
+    language: 'en-US',
+    gender: 'Female',
+    accent: 'American',
+    label: 'Warm and friendly voice',
+  },
+  {
+    id: 'Rime.ArcanaV3.kai',
+    name: 'Kai',
+    provider: 'rime',
+    language: 'en-US',
+    gender: 'Male',
+    accent: 'American',
+    label: 'Deep and calm voice',
+  },
+  {
+    id: 'Rime.ArcanaV3.luna',
+    name: 'Luna',
+    provider: 'rime',
+    language: 'en-GB',
+    gender: 'Female',
+    accent: 'British',
+    label: 'Elegant British voice',
+  },
+  {
+    id: 'Rime.ArcanaV3.connor',
+    name: 'Connor',
+    provider: 'rime',
+    language: 'en-IE',
+    gender: 'Male',
+    accent: 'Irish',
+    label: 'Friendly Irish voice',
+  },
+];
+
+function createMockClient(overrides: Partial<{
+  user: Record<string, unknown>;
+  voices: Record<string, unknown>;
+}> = {}): ClawTalkClient {
+  return {
+    user: {
+      me: vi.fn().mockResolvedValue(mockUserData),
+      updateMe: vi.fn().mockResolvedValue(mockUserData),
+      ...overrides.user,
+    },
+    voices: {
+      list: vi.fn().mockResolvedValue({
+        voices: mockVoices,
+        default_voice: 'Rime.ArcanaV3.astra',
+        providers: ['aws', 'azure', 'minimax', 'resemble', 'rime', 'telnyx'],
+      }),
+      ...overrides.voices,
+    },
+  } as unknown as ClawTalkClient;
+}
+
+// ── BotConfigTool ───────────────────────────────────────────
+
+describe('BotConfigTool', () => {
+  let tool: BotConfigTool;
+  let client: ClawTalkClient;
+  let logger: Logger;
+
+  beforeEach(() => {
+    logger = createMockLogger();
+    client = createMockClient();
+    tool = new BotConfigTool({ client, logger });
+  });
+
+  it('has correct metadata', () => {
+    expect(tool.name).toBe('clawtalk_bot_config');
+    expect(tool.label).toBe('ClawTalk Bot Config');
+    expect(tool.description).toContain('Read or update');
+  });
+
+  // ── action: get ─────────────────────────────────────────
+
+  describe('action: get', () => {
+    it('returns bot config', async () => {
+      const result = await tool.execute('tc_1', { action: 'get' });
+
+      expect(client.user.me).toHaveBeenCalled();
+
+      const details = result.details as Record<string, unknown>;
+      expect(details.agent_name).toBe('PAL-01');
+      expect(details.display_name).toBe('Ciaran');
+      expect(details.bot_role).toBe('Personal assistant');
+      expect(details.greeting).toBe('Hey, what do you need?');
+      expect(details.voice_preference).toBe('Minimax.speech-2.8-turbo.English_Aussie_Bloke');
+    });
+
+    it('handles null fields gracefully', async () => {
+      const sparseClient = createMockClient({
+        user: {
+          me: vi.fn().mockResolvedValue({ user_id: 'user_123' }),
+        },
+      });
+      const sparseTool = new BotConfigTool({ client: sparseClient, logger });
+
+      const result = await sparseTool.execute('tc_2', { action: 'get' });
+      const details = result.details as Record<string, unknown>;
+
+      expect(details.agent_name).toBeNull();
+      expect(details.bot_role).toBe('personal AI assistant'); // default
+    });
+
+    it('throws on API error', async () => {
+      const failClient = createMockClient({
+        user: { me: vi.fn().mockRejectedValue(new Error('Unauthorized')) },
+      });
+      const failTool = new BotConfigTool({ client: failClient, logger });
+
+      await expect(failTool.execute('tc_3', { action: 'get' })).rejects.toThrow('Unauthorized');
+    });
+  });
+
+  // ── action: update ──────────────────────────────────────
+
+  describe('action: update', () => {
+    it('updates bot config with provided fields', async () => {
+      const result = await tool.execute('tc_4', {
+        action: 'update',
+        greeting: 'Yo, what up?',
+        voice_preference: 'Azure.en-IE-ConnorNeural',
+      });
+
+      expect(client.user.updateMe).toHaveBeenCalledWith({
+        greeting: 'Yo, what up?',
+        voice_preference: 'Azure.en-IE-ConnorNeural',
+      });
+
+      const details = result.details as Record<string, unknown>;
+      expect(details.message).toBe('Bot config updated. Changes take effect on the next call.');
+    });
+
+    it('updates all supported fields', async () => {
+      await tool.execute('tc_5', {
+        action: 'update',
+        agent_name: 'Daisy',
+        bot_role: 'Receptionist',
+        custom_instructions: 'Be polite.',
+        greeting: 'Hello!',
+        voice_preference: 'Rime.ArcanaV3.astra',
+      });
+
+      expect(client.user.updateMe).toHaveBeenCalledWith({
+        agent_name: 'Daisy',
+        bot_role: 'Receptionist',
+        custom_instructions: 'Be polite.',
+        greeting: 'Hello!',
+        voice_preference: 'Rime.ArcanaV3.astra',
+      });
+    });
+
+    it('throws when no fields provided', async () => {
+      await expect(tool.execute('tc_6', { action: 'update' })).rejects.toThrow(
+        'No fields provided for update',
+      );
+    });
+
+    it('throws on API error', async () => {
+      const failClient = createMockClient({
+        user: { updateMe: vi.fn().mockRejectedValue(new Error('Bad request')) },
+      });
+      const failTool = new BotConfigTool({ client: failClient, logger });
+
+      await expect(
+        failTool.execute('tc_7', { action: 'update', greeting: 'Hi' }),
+      ).rejects.toThrow('Bad request');
+    });
+  });
+
+  // ── action: list_voices ─────────────────────────────────
+
+  describe('action: list_voices', () => {
+    it('lists voices for default provider (rime)', async () => {
+      const result = await tool.execute('tc_8', { action: 'list_voices' });
+
+      expect(client.voices.list).toHaveBeenCalledWith('rime');
+
+      const details = result.details as Record<string, unknown>;
+      expect(details.provider).toBe('rime');
+      expect(details.default_voice).toBe('Rime.ArcanaV3.astra');
+      expect(details.total_matching).toBe(4);
+      expect(details.showing).toBe(4);
+      expect(Array.isArray(details.voices)).toBe(true);
+    });
+
+    it('lists voices for specified provider', async () => {
+      await tool.execute('tc_9', { action: 'list_voices', provider: 'minimax' });
+
+      expect(client.voices.list).toHaveBeenCalledWith('minimax');
+    });
+
+    it('filters by language', async () => {
+      const result = await tool.execute('tc_10', {
+        action: 'list_voices',
+        language: 'en-GB',
+      });
+
+      const details = result.details as Record<string, unknown>;
+      expect(details.total_matching).toBe(1);
+
+      const voices = details.voices as Array<{ name: string }>;
+      expect(voices[0].name).toBe('Luna');
+    });
+
+    it('filters by language prefix', async () => {
+      const result = await tool.execute('tc_11', {
+        action: 'list_voices',
+        language: 'en',
+      });
+
+      const details = result.details as Record<string, unknown>;
+      expect(details.total_matching).toBe(4); // all are en-*
+    });
+
+    it('filters by gender', async () => {
+      const result = await tool.execute('tc_12', {
+        action: 'list_voices',
+        gender: 'Male',
+      });
+
+      const details = result.details as Record<string, unknown>;
+      expect(details.total_matching).toBe(2);
+
+      const voices = details.voices as Array<{ name: string }>;
+      expect(voices.map((v) => v.name)).toContain('Kai');
+      expect(voices.map((v) => v.name)).toContain('Connor');
+    });
+
+    it('filters by accent', async () => {
+      const result = await tool.execute('tc_13', {
+        action: 'list_voices',
+        accent: 'Irish',
+      });
+
+      const details = result.details as Record<string, unknown>;
+      expect(details.total_matching).toBe(1);
+
+      const voices = details.voices as Array<{ name: string }>;
+      expect(voices[0].name).toBe('Connor');
+    });
+
+    it('filters by search term', async () => {
+      const result = await tool.execute('tc_14', {
+        action: 'list_voices',
+        search: 'luna',
+      });
+
+      const details = result.details as Record<string, unknown>;
+      expect(details.total_matching).toBe(1);
+
+      const voices = details.voices as Array<{ name: string }>;
+      expect(voices[0].name).toBe('Luna');
+    });
+
+    it('searches in label', async () => {
+      const result = await tool.execute('tc_15', {
+        action: 'list_voices',
+        search: 'elegant',
+      });
+
+      const details = result.details as Record<string, unknown>;
+      expect(details.total_matching).toBe(1);
+
+      const voices = details.voices as Array<{ name: string }>;
+      expect(voices[0].name).toBe('Luna');
+    });
+
+    it('combines multiple filters', async () => {
+      const result = await tool.execute('tc_16', {
+        action: 'list_voices',
+        language: 'en',
+        gender: 'Female',
+        accent: 'British',
+      });
+
+      const details = result.details as Record<string, unknown>;
+      expect(details.total_matching).toBe(1);
+
+      const voices = details.voices as Array<{ name: string }>;
+      expect(voices[0].name).toBe('Luna');
+    });
+
+    it('caps results at 20', async () => {
+      // Create 30 voices — use unique provider to avoid cache
+      const manyVoices = Array.from({ length: 30 }, (_, i) => ({
+        id: `voice_${i}`,
+        name: `Voice ${i}`,
+        provider: 'test-many',
+        language: 'en-US',
+        gender: 'Female',
+        accent: 'American',
+        label: null,
+      }));
+
+      const manyClient = createMockClient({
+        voices: {
+          list: vi.fn().mockResolvedValue({
+            voices: manyVoices,
+            default_voice: 'voice_0',
+            providers: ['test-many'],
+          }),
+        },
+      });
+      const manyTool = new BotConfigTool({ client: manyClient, logger });
+
+      const result = await manyTool.execute('tc_17', { action: 'list_voices', provider: 'test-many' });
+
+      const details = result.details as Record<string, unknown>;
+      expect(details.total_matching).toBe(30);
+      expect(details.showing).toBe(20);
+
+      const voices = details.voices as Array<unknown>;
+      expect(voices).toHaveLength(20);
+    });
+
+    it('truncates long labels', async () => {
+      // Use unique provider to avoid cache
+      const longLabelVoice = {
+        id: 'voice_long',
+        name: 'Long Voice',
+        provider: 'test-long',
+        language: 'en-US',
+        gender: 'Female',
+        accent: 'American',
+        label: 'A'.repeat(100),
+      };
+
+      const longClient = createMockClient({
+        voices: {
+          list: vi.fn().mockResolvedValue({
+            voices: [longLabelVoice],
+            default_voice: 'voice_long',
+            providers: ['test-long'],
+          }),
+        },
+      });
+      const longTool = new BotConfigTool({ client: longClient, logger });
+
+      const result = await longTool.execute('tc_18', { action: 'list_voices', provider: 'test-long' });
+
+      const details = result.details as Record<string, unknown>;
+      const voices = details.voices as Array<{ label: string }>;
+
+      expect(voices[0].label).toHaveLength(80);
+      expect(voices[0].label.endsWith('_')).toBe(true);
+    });
+
+    it('returns providers list', async () => {
+      const result = await tool.execute('tc_19', { action: 'list_voices' });
+
+      const details = result.details as Record<string, unknown>;
+      expect(details.providers).toEqual(['aws', 'azure', 'minimax', 'resemble', 'rime', 'telnyx']);
+    });
+
+    it('throws on API error', async () => {
+      // Use unique provider to avoid cache
+      const failClient = createMockClient({
+        voices: { list: vi.fn().mockRejectedValue(new Error('Service unavailable')) },
+      });
+      const failTool = new BotConfigTool({ client: failClient, logger });
+
+      await expect(
+        failTool.execute('tc_20', { action: 'list_voices', provider: 'test-fail' }),
+      ).rejects.toThrow('Service unavailable');
+    });
+  });
+
+  // ── Unknown action ──────────────────────────────────────
+
+  describe('unknown action', () => {
+    it('throws on unknown action', async () => {
+      await expect(
+        tool.execute('tc_21', { action: 'delete' }),
+      ).rejects.toThrow('Unknown action: delete');
+    });
+  });
+});


### PR DESCRIPTION
### Summary

Adds voice browsing and configuration capabilities to the ClawTalk plugin, allowing OpenClaw agents to manage bot settings and specify voices for mission assistants.

### Changes

#### New: `clawtalk_bot_config` Tool

- **Actions:** `get`, `update`, `list_voices`
- **`get`** — Returns current bot config (name, role, greeting, voice, language, custom instructions)
- **`update`** — Updates any combination of bot settings
- **`list_voices`** — Browse available TTS voices with filters

**Voice browsing features:**
- `provider` param required (default: `rime`) — prevents dumping 2,500+ voices into context
- Client-side filters: `language`, `gender`, `accent`, `search`
- Results capped at 20 with `total_matching` count
- 5 minute TTL cache per provider

#### SDK Additions

- `VoicesNamespace` with `list(provider?)` method
- Voice types (`Voice`, `VoicesResponse`)
- `listVoices` endpoint

#### Mission Assistant Voice Override

- `clawtalk_mission_setup_agent` now accepts optional `voice` param
- If omitted, inherits user's `voice_preference` (server-side fallback)
- Removed hardcoded `Rime.ArcanaV3.astra` default from plugin

#### Other

- Version bump to `0.2.0`
- 22 new tests for BotConfigTool

### Testing

- Tested voice browsing with various providers and filters
- Verified mission assistants inherit user voice preference when not specified
- Verified explicit voice override works when specified****