### PR TITLE
fix: API check guard and improved logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clawtalk",
-  "version": "0.1.3",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clawtalk",
-      "version": "0.1.3",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.34.0",
@@ -19,8 +19,9 @@
         "@swc-node/register": "^1.11.1",
         "@swc/cli": "^0.7.8",
         "@swc/core": "^1.13.5",
-        "@types/node": "^24.3.1",
+        "@types/node": "^24.12.2",
         "@types/ws": "^8.5.13",
+        "chokidar": "^4.0.3",
         "typescript": "~5.8.3",
         "vitest": "^4.0.18"
       },
@@ -6650,7 +6651,9 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "24.12.0",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -6704,17 +6707,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/ws/node_modules/@types/node": {
-      "version": "25.4.0",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~7.18.0"
-      }
-    },
-    "node_modules/@types/ws/node_modules/undici-types": {
-      "version": "7.18.2",
-      "license": "MIT"
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -7652,6 +7644,22 @@
       "integrity": "sha512-TdngOlFV1FLTzU0o1w8MB6/BFywhtLC0SzRTGJU7T9lmdjlCWeMRt1iVo0Ki+ldwNk0BqNiKoc8xpLZEQ8mY1w==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/chownr": {
       "version": "3.0.0",
@@ -11985,6 +11993,20 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/real-require": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawtalk",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Voice calls, SMS, missions, and approvals via ClawTalk — OpenClaw plugin",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "dev": "node --import @swc-node/register/esm-register src/index.ts",
     "build": "swc src -d build --strip-leading-paths",
+    "build:watch": "swc src -d build --strip-leading-paths -w",
     "lint": "biome check .",
     "format": "biome format --write .",
     "check": "biome check --write .",
@@ -26,8 +27,9 @@
     "@swc-node/register": "^1.11.1",
     "@swc/cli": "^0.7.8",
     "@swc/core": "^1.13.5",
-    "@types/node": "^24.3.1",
+    "@types/node": "^24.12.2",
     "@types/ws": "^8.5.13",
+    "chokidar": "^4.0.3",
     "typescript": "~5.8.3",
     "vitest": "^4.0.18"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -192,9 +192,14 @@ const clawTalkPlugin = {
     // OpenClaw's plugin API logger tags all output as [gateway] — there's no
     // built-in per-plugin scoping. Channels like Slack get [slack] via the
     // channel dock's runtime.log, which is a separate system.
-    // We use api.logger directly and accept [gateway] tagging for now.
     // TODO: request per-plugin logger scoping upstream in OpenClaw.
-    const logger = api.logger;
+    const raw = api.logger;
+    const logger: typeof raw = {
+      info: (msg: string) => raw.info(`[clawtalk] ${msg}`),
+      warn: raw.warn ? (msg: string) => raw.warn!(`[clawtalk] ${msg}`) : undefined,
+      error: raw.error ? (msg: string) => raw.error!(`[clawtalk] ${msg}`) : undefined,
+      debug: raw.debug ? (msg: string) => raw.debug!(`[clawtalk] ${msg}`) : undefined,
+    };
 
     if (!config.apiKey) {
       logger.warn('ClawTalk plugin loaded without API key. Tools will fail until configured.');

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,8 @@ async function createClawTalkRuntime(params: {
 }): Promise<ClawTalkRuntime> {
   const { config, coreConfig, logger, enqueueSystemEvent, dataDir } = params;
 
+  const hasApiKey = Boolean(config.apiKey);
+
   // 1. SDK client
   const clientVersion = readPackageVersion();
   const client = new ClawTalkClient({
@@ -117,7 +119,9 @@ async function createClawTalkRuntime(params: {
     logger,
     config: config.missions.observer,
   });
-  missionObserver.start();
+  if (hasApiKey) {
+    missionObserver.start();
+  }
 
   // 9. DoctorService
   const doctor = new DoctorService({ client, ws, coreBridge, logger, openclawRoot: process.env.OPENCLAW_ROOT?.trim() });
@@ -145,8 +149,8 @@ async function createClawTalkRuntime(params: {
     }
   });
 
-  // 11. Connect WebSocket
-  if (config.autoConnect) {
+  // 11. Connect WebSocket (skip if no API key — auth will fail immediately)
+  if (hasApiKey && config.autoConnect) {
     try {
       await ws.connect();
       logger.info('ClawTalk service started');


### PR DESCRIPTION
## Summary

When the plugin loads without an API key configured, the MissionObserver and WebSocket connection still attempt to start — resulting in repeated 401 errors and auth failures polluting the logs every 5 minutes. This PR adds an auth guard so those services are skipped entirely when no API key is present.

Additionally, all plugin log messages now include a `[clawtalk]` prefix so they're easily distinguishable from other plugins in the OpenClaw log output.

## Changes

- **Auth guard**: `MissionObserver.start()` and `ws.connect()` are now gated behind a `hasApiKey` check in `createClawTalkRuntime()` — no more unnecessary network calls with empty credentials
- **Log prefix**: Wrapped the platform logger to prepend `[clawtalk]` to all `info`/`warn`/`error`/`debug` messages
- **DX**: Added `build:watch` script for watch-based development (`swc -w`)
- **Deps**: Bumped `@types/node` to `^24.12.2`, added `chokidar` dev dependency
- **Version**: `0.2.2` → `0.2.3`

## Before / After

**Before** (no API key):
```
[plugins] ClawTalk plugin loaded without API key. Tools will fail until configured.
[plugins] GET /v1/missions?page[size]=50
[plugins] API 401: GET /v1/missions?page[size]=50
[plugins] [MissionObserver] Failed to fetch missions: ... 401 — Invalid API key
[plugins] Connecting to ClawTalk WebSocket (wss://clawdtalk.com/ws)
[plugins] Authentication failed: Send auth with api_key or registration_code
```

**After** (no API key):
```
[plugins] [clawtalk] ClawTalk plugin loaded without API key. Tools will fail until configured.
[plugins] [clawtalk] ClawTalk plugin loaded (server: https://clawdtalk.com)
[plugins] [clawtalk] Registered 21 agent tools
```
No 401s. No failed WebSocket auth. Clean logs.

## Test plan

- [ ] Start OpenClaw **without** a ClawTalk API key — verify no 401 errors or WS auth failures in logs
- [ ] Start OpenClaw **with** a valid API key — verify MissionObserver and WebSocket start normally
- [ ] Confirm all clawtalk log lines show the `[clawtalk]` prefix
- [ ] Run `npm run build:watch` and verify incremental rebuilds work

🤖 Generated with [Claude Code](https://claude.com/claude-code)